### PR TITLE
feat: add is_pickable flag to coco object annotation

### DIFF
--- a/labelbox/data/serialization/coco/annotation.py
+++ b/labelbox/data/serialization/coco/annotation.py
@@ -50,6 +50,7 @@ class COCOObjectAnnotation(BaseModel):
     area: float
     bbox: Tuple[float, float, float, float]  #[x,y,w,h],
     iscrowd: int = 0
+    attributes: dict
 
 
 class PanopticAnnotation(PathSerializerMixin):


### PR DESCRIPTION
**In this PR:**

- changes required to add `attributes` object to the coco output.
- handle `is_pickable` classification/attribute

```json
...
  "annotations": [
    {
      "id": 0,
      "image_id": 0,
      "category_id": 1,
      "segmentation": [
        [
        ...
        ]
      ],
      "area": 227464.50807149993,
      "bbox": [
        ...
      ],
      "iscrowd": 0,
      "attributes": {
        "is_pickable": false
...
```