### PR TITLE
editing method for removing SAS key from azure download file_name

### DIFF
--- a/labelbox/data/serialization/coco/image.py
+++ b/labelbox/data/serialization/coco/image.py
@@ -69,7 +69,7 @@ def get_image(
         img = Image.open(io.BytesIO(image))
         h, w = img.height, img.width
         return CocoImage(
-            id=image_id, width=w, height=h, file_name=Path(label.data.url).name
+            id=image_id, width=w, height=h, file_name=Path(label.data.url).name.split('?')[0]
         )
 
 


### PR DESCRIPTION
Removing the SAS key that might appear in the file_name when doing a update_labels in labelbox-utils, which affects our coco-datasets