### PR TITLE
add/update_labels_use_metadata

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ typeguard
 imagesize
 azure-storage-blob
 loguru
+azure-utils>=1.3.0


### PR DESCRIPTION
Instead of downloading to check image size when running update-labels. It uses the metadata on blob if it exists.