### PR TITLE
Fix for extracting image filename from label from batch project.

### DIFF
--- a/labelbox/data/serialization/coco/image.py
+++ b/labelbox/data/serialization/coco/image.py
@@ -96,8 +96,9 @@ def get_image(
                 metadata=image_metadata
             )
 
+        file_name = Path(label.data.url.split('?')[0]).name
         return CocoImage(
-            id=image_id, width=w, height=h, file_name=Path(label.data.url.split('?')[0]).name
+            id=image_id, width=w, height=h, file_name=file_name
         )
 
 


### PR DESCRIPTION
Change how image filename is extracted from labelbox label object, as the url changed for batch projects.

URL examples of each:

Batch
https://r7ecommonuksdata.blob.core.windows.net/labelbox-data/dev_Levenseat_Aluminium_sample_batch/dev_levenseat_aluminium_batch_train/images/levenseat01__20220620172225957978.jpg?se=2025-12-12T17%3A46%3A08Z&sp=rt&sv=2020-04-08&sr=b&sig=gLyD5pRMQfDUd/Xm87M8MjbgkKFK6s6d/WLXxkEbv4U%3D

Dataset
https:/r7ecommonuksdata.blob.core.windows.net/labelbox-data/dev_Levenseat_Aluminium_sample/dev_levenseat_aluminium_val/images/levenseat01__20220620111815427050.jpg?se=2025-09-21T15%3A49%3A36Z&sp=rt&sv=2020-04-08&sr=b&sig=ZE7ive%2BB6UaFpQqxdPSxslDdHTwGWHMvd34ZHz0tMFE%3D


Since Batch has more "/", have to call .name on Path object at the end.

In both cases, filename is 
levenseat01__20220620172225957978.jpg
and 
levenseat01__20220620111815427050.jpg
respectively